### PR TITLE
Fixing Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ r_packages:
   - yaml
 
 script:
-  - Rscript -e "library(devtools); test()"
+  - Rscript -e 'library(devtools); checkOutput <- data.frame(test()); if (sum(checkOutput["failed"]) > 0){q(status = 1, save = "no")}'


### PR DESCRIPTION
Rscript was exit on 0 even if tests were failing, therefore travis was not showing that tests were failing. This should fix it.

What's being done there is just saving the `test()` output as a `data.frame` and summing all the errors, if the value is larger than `0` then exit with a 1.
