### PR TITLE
Time bug fix

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -3,3 +3,5 @@ Makefile
 .travis.yml
 appveyor.yml
 paper.md
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ vignettes/*.pdf
 # OAuth2 token, see https://github.com/hadley/httr/releases/tag/v0.3
 *.httr-oauth
 .Rproj.user
+*.Rproj

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ vignettes/*.pdf
 
 # OAuth2 token, see https://github.com/hadley/httr/releases/tag/v0.3
 *.httr-oauth
+.Rproj.user

--- a/R/ccTable.R
+++ b/R/ccTable.R
@@ -453,11 +453,15 @@ getEpisodePeriod <- function (e, unit="hours") {
     # anonymised or has a missing or incorrect value of discharge or admission
     # time. 
     if (is.na(tdisc)) {
+      if (is.null(findMaxTime(e))) {
+        period_length <- 0
+      } else {
         period_length <- ceiling(
           as.numeric(
             difftime(
               as.POSIXct.numeric(findMaxTime(e), origin = "1970-01-01 00:00:00"), tadm, units = unit)
           ))
+      }
     } else {
         if (any(is.null(tdisc), is.null(tadm)))
             period_length <- NULL

--- a/R/ccTable.R
+++ b/R/ccTable.R
@@ -452,9 +452,13 @@ getEpisodePeriod <- function (e, unit="hours") {
     # The failure of POSIX conversion indicates that this episode is either 
     # anonymised or has a missing or incorrect value of discharge or admission
     # time. 
-    if (is.na(tadm) || is.na(tdisc))
-        period_length <- findMaxTime(e)
-    else {
+    if (is.na(tdisc)) {
+        period_length <- ceiling(
+          as.numeric(
+            difftime(
+              as.POSIXct.numeric(findMaxTime(e), origin = "1970-01-01 00:00:00"), tadm, units = unit)
+          ))
+    } else {
         if (any(is.null(tdisc), is.null(tadm)))
             period_length <- NULL
         else
@@ -466,6 +470,8 @@ getEpisodePeriod <- function (e, unit="hours") {
         if (period_length == 0)
             period_length <- period_length + 1
     }
+    
+    
 
     if (is.null(period_length))
         warning("This episode does not have any time series data: ", 


### PR DESCRIPTION
This segment of the code caused a problem with allocation of memory.
It looks like `findMaxTime()` was the culprit returning a very high number (possibly the number of hours since 1900??)

This modification works, but may effect legacy `ccRecords` that were created outside the Postgres pipeline. I'm not very familiar with that aspect, so this needs review in the context of preserving legacy features.

I have removed reference to `is.na(tadm)` because this field is **always** present in the new system (A record can't exist without an admission time)

Many thanks in advance for input.